### PR TITLE
Update to notty v0.2.2 upsteam

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/notty"]
 	path = vendor/notty
-	url = https://github.com/alexozer/notty
+	url = https://github.com/pqwy/notty


### PR DESCRIPTION
Before this patch, I'm getting the following compilation error:

```
File "vendor/notty-0/lwt/notty_lwt.ml", line 68, characters 25-64:  
Error: This expression has type (unit -> unit) Lwt.t                 
       but an expression was expected of type unit Lwt.t
Hint: Did you forget to provide `()' as argument?   
```

Everything seams to compile with the latest netty release.