### PR TITLE
Add "draw_background" configuration option

### DIFF
--- a/examples/default-config.json
+++ b/examples/default-config.json
@@ -6,5 +6,6 @@
     "End": "DeleteSplit",
     "Backspace": "ResetAndSave",
     "Delete": "ResetAndDelete"
-  }
+  },
+  "draw_background": true
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::style::Color;
 use device_query::{DeviceQuery, DeviceState, Keycode};
 
 use crate::settings::{self, Action, Settings};
@@ -61,10 +62,13 @@ impl Timer {
             self.apply_action(action)?;
         }
 
-        self.renderer.set_default_colors(
-            parse_color(self.settings.theme.normal_text),
-            parse_color(self.settings.theme.bg),
-        );
+        let bg_color = if self.settings.draw_background {
+            parse_color(self.settings.theme.bg)
+        } else {
+            Color::Reset
+        };
+        self.renderer
+            .set_default_colors(parse_color(self.settings.theme.normal_text), bg_color);
 
         let block = view::render_view(&self.timer_state, self.settings.theme);
         self.renderer.render(&block)?;

--- a/src/view.rs
+++ b/src/view.rs
@@ -136,18 +136,15 @@ fn get_split_row(timer: &TimerState, idx: u32, theme: &Theme, summary: &[SegSumm
     let delta_col = get_delta_block(timer, idx, theme, summary);
 
     let running = matches!(timer.mode, TimerMode::Running { start_time: _ });
-    let bg_color = if running && idx as usize == timer.splits.len() {
-        theme.highlight
-    } else {
-        theme.bg
-    };
-    let bg = Image::new(
+    let mut bg_image = Image::new(
         &" ".repeat(TIMER_WIDTH as usize),
         TIMER_WIDTH,
         TextAlign::Left,
-    )
-    .bg_color(parse_color(bg_color))
-    .build();
+    );
+    if running && idx as usize == timer.splits.len() {
+        bg_image = bg_image.bg_color(parse_color(theme.highlight));
+    }
+    let bg = bg_image.build();
 
     bg.stack(Block::hcat(vec![name_col, delta_col, seg_col, split_col]))
 }


### PR DESCRIPTION
This adds an option to disable background drawing, so that the timer works nicely with transparent terminals.

Closes #37 