### PR TITLE
flitter is packaged in nixpkgs too

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Fedora/RHEL/CentOS:
 sudo dnf install xorg-x11-server-devel
 ```
 
+[Nix / NixOS](https://search.nixos.org/packages?show=flitter&query=flitter):
+
+```bash
+nix-shell -p flitter
+```
+
 ## Usage
 
 To get started, download and rename the template file [`examples/splits_minimal.json`](/examples/splits_minimal.json) to a path of your choosing. Edit the file (`title`, `category`, `split_names`) to represent your current run.


### PR DESCRIPTION
Just adds Nix / NixOS to the README as another place that flitter is packaged.

The given snippet doesn't install flitter permanently, but it shows what the package name is, which is all people will really need in order to know what to do.